### PR TITLE
modified systemd worker service startup script to enable kubectl logs

### DIFF
--- a/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/k8s-worker.service
+++ b/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/k8s-worker.service
@@ -6,7 +6,7 @@ After=docker.service
 ExecStartPre=-/usr/bin/docker kill k8s-worker k8s-worker-proxy
 ExecStartPre=-/usr/bin/docker rm k8s-worker k8s-worker-proxy
 ExecStartPre=-/bin/sh -c "mkdir -p /etc/kubernetes/static/worker"
-ExecStart=/bin/sh -c "exec docker run 													\
+ExecStart=/bin/sh -c "exec docker run 											\
 					--name=k8s-worker 													\
 					--net=host 															\
 					-v /etc/kubernetes/static/worker:/etc/kubernetes/manifests			\
@@ -16,7 +16,7 @@ ExecStart=/bin/sh -c "exec docker run 													\
 					-v /var/lib/docker/:/var/lib/docker:rw 								\
 					-v /var/lib/kubelet:/var/lib/kubelet:rw 							\
 					-v /var/run:/var/run:rw 											\
-					--privileged 														\
+					--privileged=true										\
 					--pid=host 															\
 					kubernetesonarm/hyperkube /hyperkube kubelet 						\
 						--allow-privileged=true 										\
@@ -26,7 +26,7 @@ ExecStart=/bin/sh -c "exec docker run 													\
 						--cluster-dns=10.0.0.10 										\
 						--cluster-domain=cluster.local 									\
 						--v=2 															\
-						--address=127.0.0.1												\
+						--address=0.0.0.0  												\
 						--enable-server 												\
 						--hostname-override=$(ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1) \
 						--config=/etc/kubernetes/manifests"
@@ -34,11 +34,9 @@ ExecStart=/bin/sh -c "exec docker run 													\
 ExecStartPost=/usr/bin/docker run -d 													\
 						--name=k8s-worker-proxy 										\
 						--net=host 														\
-						--privileged 													\
+						--privileged=true									\
 						kubernetesonarm/hyperkube /hyperkube proxy 						\
 							--master=http://${K8S_MASTER_IP}:8080 						\
-							--proxy-mode=iptables										\
-							--resource-container=""										\
 							--v=2
 ExecStop=/usr/bin/docker stop k8s-worker k8s-worker-proxy
 EnvironmentFile=/etc/kubernetes/k8s.conf


### PR DESCRIPTION
Hello - here is a proposed fix for issue #38 

This modification allowed the successful execution of kubectl logs in a multi node arch setup using RPI-2's.