### PR TITLE
Invalid name fix:metadata.labels: invalid value 'Kubernetes Dashboard'

### DIFF
--- a/addons/dashboard.yaml
+++ b/addons/dashboard.yaml
@@ -31,7 +31,7 @@ metadata:
   labels:
     k8s-app: kubernetes-dashboard
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "Kubernetes Dashboard"
+    kubernetes.io/name: "Dashboard"
   name: kubernetes-dashboard
   namespace: kube-system
 spec:


### PR DESCRIPTION
The metadata.labels name was invalid:
metadata.labels: invalid value 'Kubernetes Dashboard', Details: must have at most 63 characters, matching regex (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?: e.g. "MyValue" o
/Regards