### PR TITLE
change shared mounts for /var/lib/kubelet to rw

### DIFF
--- a/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/k8s-master.service
+++ b/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/k8s-master.service
@@ -15,7 +15,7 @@ ExecStart=/bin/sh -c "exec docker run \
 					-v /sys:/sys:ro \
 					-v /dev:/dev \
 					-v /var/lib/docker/:/var/lib/docker:rw \
-					-v /var/lib/kubelet:/var/lib/kubelet:shared \
+					-v /var/lib/kubelet:/var/lib/kubelet:rw \
 					-v /var/run:/var/run:rw \
 					--privileged \
 					kubernetesonarm/hyperkube \

--- a/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/k8s-worker.service
+++ b/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/k8s-worker.service
@@ -15,7 +15,7 @@ ExecStart=/bin/sh -c "exec docker run \
 					-v /sys:/sys:ro \
 					-v /dev:/dev \
 					-v /var/lib/docker/:/var/lib/docker:rw \
-					-v /var/lib/kubelet:/var/lib/kubelet:shared \
+					-v /var/lib/kubelet:/var/lib/kubelet:rw \
 					-v /var/run:/var/run:rw \
 					--privileged \
 					kubernetesonarm/hyperkube \


### PR DESCRIPTION
It turns out that on docker 1.10+, shared mounts and kubernetes don't play well together. Luckily, falling back to rw seems to fix it. I am not sure why hyperkube suggests a shared mount for this, but the cluster seems to work with it being rw instead. Again, this is on hypriotos.

https://github.com/kubernetes/kubernetes/issues/18239