### PR TITLE
Implement support for odroid-c2 + ubuntu

### DIFF
--- a/sdcard/os/debian.sh
+++ b/sdcard/os/debian.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# First invoked by sdcard/write
+mountpartitions(){
+  # Partition the sd card
+  # There's nothing to do here, because all this is made with dd
+  echo "No extra partition work has to be done. Continuing..."
+}
+
+# Invoked by sdcard/write
+cleanup(){
+  case $MACHINENAME in
+    rpi|rpi-2|rpi-3)
+      umount_root;;
+    *)
+      exit;;
+  esac
+}
+
+extract_archive(){
+  echo "Extracting Archive using unzip"
+  unzip $1 -d $2
+}
+
+
+# Takes an URL (.img.zip file) to download an the name of the downloaded file. Assumes that the extracted and the downloaded file has the same names except for the extension
+generaldownload(){
+
+  # Install unzip and partprobe if not present
+  require unzip unzip
+  require partprobe partprobe
+
+  # We can't write this .img file to /tmp because /tmp has a limit of 462MB
+  DLDIR=/etc/tmp/koa-$(echo $1 | md5sum | awk '{print $1}')
+  DL_LINK=$1
+  IMAGE_NAME=$2
+  ROOT_PARTITION=$3
+  ZIPFILE=$(basename $DL_LINK)
+
+  # Ensure this page is present
+  mkdir -p $DLDIR
+
+  # Do not overwrite the .img.zip file if that release already exists
+  if [[ ! -f $DLDIR/$ZIPFILE ]]; then
+    curl -sSL $DL_LINK > $DLDIR/$ZIPFILE
+  else
+    echo "No need to download archive, archive exists"
+  fi
+
+  # Do not overwrite the .img file if that release already exists
+  if [[ ! -f $DLDIR/$IMAGE_NAME ]]; then
+    extract_archive $DLDIR/$ZIPFILE $DLDIR
+  else
+    echo "No need to extract archive, image exists"
+  fi
+
+  dd if=$DLDIR/$IMAGE_NAME of=$SDCARD bs=4M
+
+  sync
+
+  # Clear old mounts, if any
+  umount $ROOT_PARTITION
+  # Force kernel to reload partitions
+  partprobe
+
+  mount $ROOT_PARTITION $ROOT
+  # Will take ~9 mins on a Pi
+}
+
+umount_root(){
+  umount $ROOT
+}

--- a/sdcard/os/hypriotos.sh
+++ b/sdcard/os/hypriotos.sh
@@ -1,94 +1,17 @@
-
+#!/bin/bash
 
 RPI_HYPRIOTOS_RELEASE="hypriot-rpi-20151115-132854"
 RPI_DOWNLOAD_LINK=http://downloads.hypriot.com/${RPI_HYPRIOTOS_RELEASE}.img.zip
+RPI_IMAGE_NAME=${RPI_HYPRIOTOS_RELEASE}.img
 
-# Wait until these images are ready with a newer kernel and more free space partitioned
-ODROID_C1_HYPRIOTOS_VERSION="v0.2.1"
-ODROID_C1_HYPRIOTOS_RELEASE="sd-card-odroid-c1-${ODROID_C1_HYPRIOTOS_VERSION}"
-ODROID_C1_DOWNLOAD_LINK=https://github.com/hypriot/image-builder-odroid-c1/releases/download/${ODROID_C1_HYPRIOTOS_VERSION}/${ODROID_C1_HYPRIOTOS_RELEASE}.img.zip
-
-# Add odroid-c1 support:
-# 
-# initos(){
-#+      odroid-c1)
-#+          generaldownload $ODROID_C1_DOWNLOAD_LINK $ODROID_C1_HYPRIOTOS_RELEASE $PARTITION1;;
-# }
-
-# cleanup(){
-#+      rpi|rpi-2|odroid-c1)
-#-      rpi|rpi-2)
-# }
-
-
-# First invoked by sdcard/write
-mountpartitions(){
-    # Partition the sd card
-    # There's nothing to do here, because all this is made with dd
-    echo "No extra partition work has to be done. Continuing..."
-}
+. ./os/debian.sh
 
 # Invoked by sdcard/write
 initos(){
-    case $MACHINENAME in
-        rpi|rpi-2|rpi-3)
-            generaldownload $RPI_DOWNLOAD_LINK $RPI_HYPRIOTOS_RELEASE $PARTITION2;;
-        *)
-            exit;;
-    esac
-}
-
-# Invoked by sdcard/write
-cleanup(){
-    case $MACHINENAME in
-        rpi|rpi-2|rpi-3)
-            umount_root;;
-        *)
-            exit;;
-    esac
-}
-
-
-# Takes an URL (.img.zip file) to download an the name of the downloaded file. Assumes that the extracted and the downloaded file has the same names except for the extension
-generaldownload(){
-
-    # Install unzip and partprobe if not present
-    require unzip unzip
-    require partprobe partprobe
-
-    # We can't write this .img file to /tmp because /tmp has a limit of 462MB
-    DLDIR=/etc/tmp/downloadhypriot
-    DL_LINK=$1
-    RELEASE=$2
-    ROOT_PARTITION=$3
-    ZIPFILE=$DLDIR/${RELEASE}.img.zip
-
-    # Ensure this page is present
-    mkdir -p $DLDIR
-
-    # Do not overwrite the .img.zip file if that release already exists
-    if [[ ! -f $ZIPFILE ]]; then
-        curl -sSL $DL_LINK > $ZIPFILE
-    fi
-
-    # Do not overwrite the .img file if that release already exists
-    if [[ ! -f $DLDIR/${RELEASE}.img ]]; then
-        unzip $ZIPFILE -d $DLDIR
-    fi
-
-    dd if=$DLDIR/${RELEASE}.img of=$SDCARD bs=4M
-
-    sync
-
-    # Clear old mounts, if any
-    umount $ROOT_PARTITION >> $LOGFILE 2>&1
-    # Force kernel to reload partitions
-    partprobe
-
-    mount $ROOT_PARTITION $ROOT
-    # Will take ~9 mins on a Pi
-}
-
-umount_root(){
-    umount $ROOT
+  case $MACHINENAME in
+    rpi|rpi-2|rpi-3)
+      generaldownload $RPI_DOWNLOAD_LINK $RPI_IMAGE_NAME $PARTITION2;;
+    *)
+      exit;;
+  esac
 }

--- a/sdcard/os/ubuntu.sh
+++ b/sdcard/os/ubuntu.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+ODROID_C2_DOWNLOAD_LINK=https://s3.amazonaws.com/odroid-c2/odroid-c2-base.img.tar.gz
+ODROID_C2_IMAGE_NAME=odroid-c2-base.img
+
+. ./os/debian.sh
+
+cleanup(){
+  case $MACHINENAME in
+    odroid-c2)
+      umount_root;;
+    *)
+      exit;;
+  esac
+}
+
+extract_archive(){
+  echo "Extracting Archive using tar"
+  tar -xzvf $1 -C $2
+}
+
+# Invoked by sdcard/write
+initos(){
+  case $MACHINENAME in
+    odroid-c2)
+      generaldownload $ODROID_C2_DOWNLOAD_LINK $ODROID_C2_IMAGE_NAME $PARTITION2;;
+    *)
+      exit;;
+  esac
+}

--- a/sdcard/rootfs/kube-systemd/dynamic-rootfs.sh
+++ b/sdcard/rootfs/kube-systemd/dynamic-rootfs.sh
@@ -17,8 +17,6 @@ rootfs(){
     ln -s ../../etc/kubernetes/source/scripts/run-test.sh $ROOT/usr/bin/run-test
 
     # Copy current source
-    # TODO: test if this mkdir could be removed
-    # mkdir -p $K8S_DIR/source
     cp -r $PROJROOT $K8S_DIR/source
 
     # Remove the .sh

--- a/sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/board/odroid-c2.sh
+++ b/sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/board/odroid-c2.sh
@@ -1,0 +1,5 @@
+# This command is run by kube-config when doing "kube-config install"
+board_post_install(){
+  # odroid patch, specific to this rootfs. Disable overlay, because linux 3.14 doesn't have overlay support
+  sed -e "s@overlay@aufs@" -i $KUBERNETES_CONFIG
+}

--- a/sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/os/ubuntu.sh
+++ b/sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/os/ubuntu.sh
@@ -1,0 +1,35 @@
+os_install(){
+
+  # Update the system and use pacman to install all the packages
+  # The two commands may be combined, but I leave it as is for now.
+  os_upgrade
+
+  # If brctl isn't installed, install it
+  if [[ ! -f $(which brctl 2>&1) ]]; then
+    apt-get install bridge-utils -y
+  fi
+  # If curl isn't installed, install it
+  if [[ ! -f $(which curl 2>&1) ]]; then
+    apt-get install curl -y
+  fi
+  apt-get install aufs-tools
+}
+
+
+os_upgrade(){
+  echo "Upgrading packages..."
+  apt-get update -y && apt-get upgrade -y
+}
+
+os_post_install(){
+  newhostname=$(hostnamectl | grep hostname | awk '{print $3}')
+}
+
+os_addon_dns(){
+  # Write the DNS options to the file
+  updateline /etc/dhcp/dhclient.conf "prepend domain-search" "prepend domain-search \"default.svc.$DNS_DOMAIN\",\"svc.$DNS_DOMAIN\",\"$DNS_DOMAIN\";"
+  updateline /etc/dhcp/dhclient.conf "prepend domain-name-servers" "prepend domain-name-servers $DNS_IP;"
+
+  # Flush changes
+  systemctl restart networking
+}

--- a/sdcard/write.sh
+++ b/sdcard/write.sh
@@ -62,11 +62,13 @@ Explanation:
             - parallella - Adepteva Parallella board. Note: Awfully slow. Do not use as-is. But you're welcome to hack and improve it. Should have a newer kernel (only with archlinux)
             - cubietruck - Cubietruck (only with archlinux)
             - bananapro - Banana Pro (only with archlinux)
+            - odroid-c2 - ODroid-C2 (only with ubuntu)
     os - The operating system which should be downloaded and installed.
         - Currently supported:
             - archlinux - Arch Linux ARM
             - hypriotos - HypriotOS
             - rancheros - RancherOS (only with rpi-2 and rpi-3)
+            - ubuntu    - Ubuntu (only odroid-c2)
     rootfs - Prepopulated rootfs with scripts and such.
         - Currently supported: 
             - kube-systemd - Kubernetes scripts prepopulated (only with archlinux and hypriotos)


### PR DESCRIPTION
This PR implements support for the odroid c2 board and it's accompanying ubuntu os. The OS image is heavily modified from the official odroid image(new kernel and things) and is also very small(1.5gb). I'm hosting it on s3, and will try to keep it up to date as necessary.

Because it's on an older kernel, it has to use aufs instead of overlay.

Unfortunately, this doesn't actually work on latest dev because of https://github.com/docker/docker/issues/18508. Once a new version of docker with the fixes gets rolled it will just start working.


