### PR TITLE
Fix ip masqing for applications like glusterfs

### DIFF
--- a/sdcard/rootfs/kube-systemd/etc/kubernetes/dropins/docker-flannel.conf
+++ b/sdcard/rootfs/kube-systemd/etc/kubernetes/dropins/docker-flannel.conf
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/docker daemon \
     --storage-driver=${DOCKER_STORAGE_DRIVER} \
     --bip=${FLANNEL_SUBNET} \
     --mtu=${FLANNEL_MTU} \
+    --ip-masq=false \
     --insecure-registry=registry.kube-system.svc.cluster.local:5000 \
     --insecure-registry=10.0.0.20:5000 \
     --insecure-registry=registry.kube-system:5000 \

--- a/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/flannel.service
+++ b/sdcard/rootfs/kube-systemd/usr/lib/systemd/system/flannel.service
@@ -14,7 +14,8 @@ ExecStart=/usr/bin/docker -H unix:///var/run/system-docker.sock run \
         -v /var/lib/kubernetes/flannel:/run/flannel \
         kubernetesonarm/flannel \
         /flanneld \
-            --etcd-endpoints=http://${K8S_MASTER_IP}:4001
+            --etcd-endpoints=http://${K8S_MASTER_IP}:4001 \
+            --ip-masq=true
 ExecStop=/usr/bin/docker -H unix:///var/run/system-docker.sock stop k8s-flannel
 
 [Install]


### PR DESCRIPTION
This fixes an issue where applications that don't know how to handle ip masqs , like glusterfs, can work normally. It moves masq up to flannel away from docker, which allows gluster to find the container ip instead of the host ip.

Apparently this is also the preferred configuration because flannel knows more about IPs than docker does.