### PR TITLE
add shell run by "kube-config install" for rpi-3 board

### DIFF
--- a/sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/board/rpi-3.sh
+++ b/sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/board/rpi-3.sh
@@ -1,0 +1,14 @@
+# This command is run by kube-config when doing "kube-config install"
+board_post_install(){
+
+    # Enable memory and swap accounting if they doesn't exist already
+    
+    if [[ -z $(grep "swapaccount=1" /boot/cmdline.txt) ]]; then
+        sed -e "s@console=tty1@console=tty1 swapaccount=1@" -i /boot/cmdline.txt
+    fi
+
+    if [[ -z $(grep "cgroup_enable=memory" /boot/cmdline.txt) ]]; then
+        sed -e "s@console=tty1@console=tty1 cgroup_enable=memory@" -i /boot/cmdline.txt
+    fi
+         
+}


### PR DESCRIPTION
I just copied the rpi-2.sh to rpi-3.sh. Currently when run `kube-config install`,  it cannot find a file named 'rpi-3' under `sdcard/rootfs/kube-systemd/etc/kubernetes/dynamic-env/board`

related to [issue92 Invalid board: rpi-3. That value does not exist](https://github.com/luxas/kubernetes-on-arm/issues/92)