### PR TITLE
Automate k8es installation completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ kube-config install
 # Last question is whether you want to reboot
 # You have to reboot in order to get the cgroups working
 
-# If you want to run this script non-interactively, do this:
-# TIMEZONE=Europe/Helsinki SWAP=1 NEW_HOSTNAME=mynewpi REBOOT=0 kube-config install
+# If you want to run this script non-interactively, provide the user input beforehand:
+# "\n" is the delimiter, "\" the escape character, presssing enter can be simulated with "\n"
+# Example:
+# /bin/echo -e "rpi-3\nhypriotos\nnodename\nEurope\/Berlin\n\n\ny\nY" | sudo kube-config install
 # This script runs in 2-3 mins
 ```
 


### PR DESCRIPTION
The existing instructions do not support a fully automated installation of K8es when running `kube-config install`. It lacks the parameters `BOARD` and `OS`. I tried to predefine them as well, but wasn't successful. 

This proposal automates the install completely.

An even nicer automation could be done with the `expect` programm, but this works fine with me.

@luxas Please review and merge.