### PR TITLE
Fixed reload script as <<< is not supported by busybox sh

### DIFF
--- a/addons/images/loadbalancer/haproxy_reload
+++ b/addons/images/loadbalancer/haproxy_reload
@@ -23,6 +23,6 @@
 # -s soft reload, wait for pids to finish handling requests
 # -f send pids a resume signal if reload of new config fails
 
-socat /tmp/haproxy - <<< "show servers state" > /var/state/haproxy/global
+echo "show servers state" | socat /tmp/haproxy - > /var/state/haproxy/global
 
 haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -D -sf $(cat /var/run/haproxy.pid)


### PR DESCRIPTION
Busybox's version of sh even when called as bash does not accept the <<< construct used by the reload_haproxy script to provide a string on stdin. Switched to the less efficient but more supported 'echo' method.