### PR TITLE
Print error and exit with 1 if git is not found on path.

### DIFF
--- a/sdcard/rootfs/docker-multinode/usr/bin/kube-config
+++ b/sdcard/rootfs/docker-multinode/usr/bin/kube-config
@@ -7,6 +7,11 @@ if [[ ${K8S_DEBUG} == 1 ]]; then
     set -x
 fi
 
+if $(hash git 2>&1 | grep -q "not found"); then
+    echo "git not installed. You need git to continue."
+    exit 1
+fi
+
 INSTALL_DEFAULT_TIMEZONE="Europe/Helsinki"
 INSTALL_DEFAULT_HOSTNAME="kubepi"
 INSTALL_DEFAULT_STORAGEDRIVER="overlay"


### PR DESCRIPTION
I see that git is in Recommends in the debian-control-file. However its nice to alert the user that git is a requirement when running kube-config. Because kube-config will not succeed without git.