### PR TITLE
Race condition in sdcard/os/hypriotos.sh

### DIFF
--- a/sdcard/os/hypriotos.sh
+++ b/sdcard/os/hypriotos.sh
@@ -99,7 +99,7 @@ generaldownload(){
         partprobe
     fi
 
-    mount $ROOT_PARTITION $ROOT
+    sleep 1s && mount $ROOT_PARTITION $ROOT
     # Will take ~9 mins on a Pi
 }
 


### PR DESCRIPTION
Adding a sleep for one second as buffer for using this in a higher latency environment such as on a VM. For example if you are using USB emulation pass through from bare metal not having a buffer will result in a race condition. You will receive a device does not exist error:

```
mount: special device /dev/sdb2 does not exist
```

Race condition found on:

```
Virtualized OS: Ubuntu 16.04 LTS
Virtualization Method: Virtualbox
USB Device: Transcend USB3.0 SD card reader
Host OS: Windows 10
```